### PR TITLE
fix: don't ignore schemas of contained resources

### DIFF
--- a/cumulus_fhir_support/__init__.py
+++ b/cumulus_fhir_support/__init__.py
@@ -1,5 +1,5 @@
 """FHIR support code for the Cumulus project"""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from .schemas import pyarrow_schema_from_rows


### PR DESCRIPTION
If a field appears in {"contained": [{my resource fields}]}, it will now also appear in the resulting schema.

If multiple resources are in the contained list, we'll use all the relevant resource schema to find the column schema for mentioned fields. This is slightly janky, but it's not clear how else to handle this without pulling resources out of the contained list. A project for the future.