### PR TITLE
Support upcoming FHIRDate changes in fhirclient

### DIFF
--- a/cumulus_fhir_support/__init__.py
+++ b/cumulus_fhir_support/__init__.py
@@ -1,6 +1,6 @@
 """FHIR support code for the Cumulus project"""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 from .json import list_multiline_json_in_dir, read_multiline_json, read_multiline_json_from_dir
 from .schemas import pyarrow_schema_from_rows

--- a/cumulus_fhir_support/schemas.py
+++ b/cumulus_fhir_support/schemas.py
@@ -239,6 +239,6 @@ def _basic_fhir_to_pyarrow_type(pytype: type) -> pyarrow.DataType:
         return pyarrow.string()
     elif pytype is bool:
         return pyarrow.bool_()
-    elif pytype is fhirdate.FHIRDate:
+    elif issubclass(pytype, fhirdate.FHIRDate):
         return pyarrow.string()  # just leave it as a string, like it appears in the JSON
     raise ValueError(f"Unexpected type: {pytype}")


### PR DESCRIPTION
Use a `issubclass` check instead of an `is` check.