### PR TITLE
feat(schema): add support for extensions on primitive types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/cumulus_fhir_support/__init__.py
+++ b/cumulus_fhir_support/__init__.py
@@ -1,6 +1,6 @@
 """FHIR support code for the Cumulus project"""
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 
 from .json import list_multiline_json_in_dir, read_multiline_json, read_multiline_json_from_dir
 from .schemas import pyarrow_schema_from_rows


### PR DESCRIPTION
i.e. add support for "sunder" fields like _status (sibling of status).

See http://hl7.org/fhir/R4/json.html#primitive for more details.

Example:
```json
{
  "birthDate": "1970-03-30",
  "_birthDate": {
    "id": "314159",
    "extension": [ {
       "url": "http://example.org/fhir/StructureDefinition/text",
       "valueString": "Easter 1970"
    }]
  }
}
```

These fields will be in the resulting schema if they are present in the input rows, else they will be left off.