### PR TITLE
fix: don't take up more memory than needed when calculating schema

### DIFF
--- a/cumulus_fhir_support/__init__.py
+++ b/cumulus_fhir_support/__init__.py
@@ -1,6 +1,6 @@
 """FHIR support code for the Cumulus project"""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 from .ml_json import list_multiline_json_in_dir, read_multiline_json, read_multiline_json_from_dir
 from .schemas import pyarrow_schema_from_rows


### PR DESCRIPTION
Previously, we expanded the iterator of rows we were handed and turned it into an in-memory list. (This didn't used to matter too much, since all known consumers were holding the rows in memory already.)

But this isn't actually necessary - we can just iterate through the rows once and calculate what we need. Which allows for "larger than memory" datasets as needed.