### PR TITLE
feat(json): add transparent support for .gz files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3  # keep in rough sync with pyproject.toml
+    rev: v0.11.6  # keep in rough sync with pyproject.toml
     hooks:
       - name: Ruff formatting
         id: ruff-format

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ pip install cumulus-fhir-support
 Lists available multiline JSON files in the target directory
 (allowing filtering by FHIR resource).
 
+Files with the `.jsonl` or `.ndjson` suffixes are supported.
+Files with an additional `.gz` suffix will also be returned.
+
 ```python3
 import cumulus_fhir_support
 
 cumulus_fhir_support.list_multiline_json_in_dir("/")
 # {
-#     "/con1.ndjson": "Condition",
+#     "/con1.ndjson.gz": "Condition",
 #     "/pat1.jsonl": "Patient",
 #     "/random.jsonl": None,
 # }
@@ -32,7 +35,7 @@ cumulus_fhir_support.list_multiline_json_in_dir("/", "Patient")
 
 cumulus_fhir_support.list_multiline_json_in_dir("/", ["Condition", "Patient"])
 # {
-#     "/con1.ndjson": "Condition",
+#     "/con1.ndjson.gz": "Condition",
 #     "/pat1.jsonl": "Patient",
 # }
 
@@ -48,6 +51,8 @@ cumulus_fhir_support.list_multiline_json_in_dir("s3://mybucket/", fsspec_fs=s3_f
 ### read_multiline_json
 
 Iterates over a single multiline JSON file.
+
+Files with the `.gz` extension are automatically uncompressed.
 
 ```python3
 import cumulus_fhir_support
@@ -71,6 +76,8 @@ list(cumulus_fhir_support.read_multiline_json("/mybucket/procs.ndjson", fsspec_f
 
 Iterates over every JSON object in a directory
 (allowing filtering by FHIR resource).
+
+Files with the `.gz` extension are automatically uncompressed.
 
 ```python3
 import cumulus_fhir_support

--- a/cumulus_fhir_support/__init__.py
+++ b/cumulus_fhir_support/__init__.py
@@ -1,6 +1,6 @@
 """FHIR support code for the Cumulus project"""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 
 from .ml_json import list_multiline_json_in_dir, read_multiline_json, read_multiline_json_from_dir
 from .schemas import pyarrow_schema_from_rows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "pre-commit",
     # Ruff is using minor versions for breaking changes until their 1.0 release.
     # See https://docs.astral.sh/ruff/versioning/
-    "ruff < 0.10",  # keep in rough sync with pre-commit-config.yaml
+    "ruff < 0.12",  # keep in rough sync with pre-commit-config.yaml
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This will let us save a bunch of space in our ndjson archives.

And while I'm here, bump the version of ruff supported.