### PR TITLE
fix: provide status code in http error messages

### DIFF
--- a/cumulus_fhir_support/http.py
+++ b/cumulus_fhir_support/http.py
@@ -224,7 +224,7 @@ async def _request_once(
             error_class = FatalNetworkError
 
         raise error_class(
-            f'An error occurred when connecting to "{url}": {message}',
+            f'An error occurred when connecting to "{url}": [{response.status_code}] {message}',
             response,
         ) from exc
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -415,7 +415,7 @@ IRxyq6i4LnRleQHDKzI0hdZJPEQd3k3RsPC9IsBf0A==
         with self.assertRaisesRegex(
             cfs.AuthError,
             'An error occurred when connecting to "https://auth.example.com/token": '
-            f"{expected_error}",
+            f"\[400] {expected_error}",
         ):
             async with cfs.FhirClient(
                 self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks


### PR DESCRIPTION
Inspired by Epic who gave us back a 404 that just said "Resource not found", but since "Resource" is a very overloaded term in FHIR, it would have been nice if the error message I ended up seeing tagged it as a 404 error and I knew that it was not a FHIR resource, but a general HTTP resource that was not found.