### PR TITLE
json: add recursive=False arguments to ndjson reader/lister

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6  # keep in rough sync with pyproject.toml
+    rev: v0.13.1  # keep in rough sync with pyproject.toml
     hooks:
       - name: Ruff formatting
         id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ include = [
 [project.optional-dependencies]
 tests = [
     "ddt",
+    "fsspec",
     "pytest",
     "pytest-cov",
     "respx",
@@ -47,7 +48,7 @@ dev = [
     "pre-commit",
     # Ruff is using minor versions for breaking changes until their 1.0 release.
     # See https://docs.astral.sh/ruff/versioning/
-    "ruff < 0.12",  # keep in rough sync with pre-commit-config.yaml
+    "ruff < 0.14",  # keep in rough sync with .pre-commit-config.yaml
 ]
 
 [tool.ruff]


### PR DESCRIPTION
While there, improve the symlink handling:
- We now follow symlinks and return the destintation
- We skip duplicate symlinks