### PR TITLE
schema: expand Period schemas, if either of the fields are present

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -158,6 +158,22 @@ class SchemaDetectionTests(unittest.TestCase):
             schema.field("onsetRange").type,
         )
 
+    def test_nested_period_is_expanded(self):
+        rows = [
+            {"dispenseRequest": {"validityPeriod": {"start": "2020-10-30"}}},
+        ]
+        schema = support.pyarrow_schema_from_rows("MedicationRequest", rows)
+        self.assertEqual(
+            pyarrow.struct(
+                {
+                    "id": pyarrow.string(),
+                    "end": pyarrow.string(),
+                    "start": pyarrow.string(),
+                }
+            ),
+            schema.field("dispenseRequest").type.field("validityPeriod").type,
+        )
+
     def test_schema_types_are_coerced(self):
         """Verify that fields with "wrong" input types (like int instead of float) are corrected"""
         # Make sure that we include both wide and deep fields.


### PR DESCRIPTION
i.e. if period.end is there, but not .start - still return .start in our schema - just as a kindness to consumers that likely will always want both.

This will also likely be useful for any future attempt by Library to coalesce various complicated dates into one value.

Fixes https://github.com/smart-on-fhir/cumulus/issues/66