### PR TITLE
schema: guarantee no empty structs in schema tree

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -182,7 +182,6 @@ class SchemaDetectionTests(unittest.TestCase):
                 {
                     "id": pyarrow.string(),
                     "display": pyarrow.string(),
-                    "identifier": pyarrow.struct({}),
                     "reference": pyarrow.string(),
                     "type": pyarrow.string(),
                 }


### PR DESCRIPTION
Some consumers like DuckDB do not support them.