### PR TITLE
A few json/http fixes

### DIFF
--- a/cumulus_fhir_support/__init__.py
+++ b/cumulus_fhir_support/__init__.py
@@ -4,6 +4,7 @@ __version__ = "1!0.0.0"
 
 from .auth import AuthError, AuthFailed, BadAuthArguments
 from .client import FhirClient, ServerType
+from .errors import RequestError
 from .http import (
     FatalNetworkError,
     NetworkError,

--- a/cumulus_fhir_support/auth.py
+++ b/cumulus_fhir_support/auth.py
@@ -10,10 +10,10 @@ from collections.abc import Iterable
 import httpx
 from jwcrypto import jwk, jwt
 
-from . import http
+from . import errors, http
 
 
-class AuthError(Exception):
+class AuthError(errors.RequestError):
     """Root of all authentication issues"""
 
 
@@ -102,7 +102,7 @@ class JwtAuth(Auth):
             )
             self._access_token = response.json().get("access_token")
         except http.NetworkError as exc:
-            raise AuthFailed(str(exc))
+            raise AuthFailed(f"Could not authenticate: {exc}") from exc
 
     def sign_headers(self) -> dict[str, str]:
         """Add signature token to request headers"""

--- a/cumulus_fhir_support/errors.py
+++ b/cumulus_fhir_support/errors.py
@@ -1,0 +1,7 @@
+class RequestError(Exception):
+    """
+    An error that occurred while trying to process a network request.
+
+    This could be directly from an http response, or during authentication, or during
+    post-response processing. Subclasses will let you differentiate.
+    """

--- a/cumulus_fhir_support/http.py
+++ b/cumulus_fhir_support/http.py
@@ -8,8 +8,10 @@ from json import JSONDecodeError
 
 import httpx
 
+from . import errors
 
-class NetworkError(Exception):
+
+class NetworkError(errors.RequestError):
     """
     A network error
 
@@ -177,7 +179,8 @@ async def _request_once(
     try:
         response = await client.send(request, stream=stream)
     except httpx.HTTPError as exc:
-        raise FatalNetworkError(str(exc), None) from exc
+        # This could be a DNS error, read error (sudden disconnect), a timeout, or who knows.
+        raise TemporaryNetworkError(str(exc), None) from exc
 
     try:
         response.raise_for_status()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -132,9 +132,10 @@ class HttpTests(unittest.IsolatedAsyncioTestCase):
         )
 
     @mock.patch("httpx.AsyncClient.send")
-    async def test_invalid_dns(self, mock_send):
+    @mock.patch("asyncio.sleep")
+    async def test_invalid_dns(self, mock_sleep, mock_send):
         """Verify that random pre-response errors bubble up as FatalErrors."""
         mock_send.side_effect = httpx.ConnectTimeout("Connect timeout")
-        with self.assertRaisesRegex(cfs.FatalNetworkError, "Connect timeout") as cm:
+        with self.assertRaisesRegex(cfs.TemporaryNetworkError, "Connect timeout") as cm:
             await cfs.http_request(httpx.AsyncClient(), "GET", "http://example.invalid/")
         self.assertIsNone(cm.exception.response)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -276,8 +276,10 @@ class NdjsonTests(unittest.TestCase):
             self.fill_dir(f"{tmpdir}/root", {"root.ndjson": [{"id": "root"}]})
             self.fill_dir(f"{tmpdir}/root/subdir", {"sub.ndjson": [{"id": "sub"}]})
             os.symlink("../external-dir", f"{tmpdir}/root/external-dir")  # should follow
-            os.symlink("subdir/sub.ndjson", f"{tmpdir}/root/link.ndjson")  # should be ignored
-            os.symlink("../external.ndjson", f"{tmpdir}/root/outer.ndjson")  # should be included
+            os.symlink("../external-link", f"{tmpdir}/root/outer.ndjson")  # should follow
+            os.symlink("external.ndjson", f"{tmpdir}/external-link")  # should follow (again)
+
+            # Confirm we iterate recursively if asked
             with self.assert_no_logs():
                 files = support.list_multiline_json_in_dir(
                     f"{tmpdir}/root", fsspec_fs=fs, recursive=True
@@ -289,6 +291,17 @@ class NdjsonTests(unittest.TestCase):
                     f"{tmpdir}/external.ndjson",
                     f"{tmpdir}/root/root.ndjson",
                     f"{tmpdir}/root/subdir/sub.ndjson",
+                ],
+            )
+
+            # And once without the flag
+            with self.assert_no_logs():
+                files = support.list_multiline_json_in_dir(f"{tmpdir}/root", fsspec_fs=fs)
+            self.assertEqual(
+                list(files),
+                [
+                    f"{tmpdir}/external.ndjson",
+                    f"{tmpdir}/root/root.ndjson",
                 ],
             )
 


### PR DESCRIPTION
# Fix 1: json: fix the default recursive=False to work again
We were accidentally always recursing. Whoops.

I broke this when I added symlink support, I believe. And I just forgot to consider or test the non-recursive flow. We didn't notice it in the broader Cumulus ecosystem, because we so often run with recursive=True.

# Fix 2: json: when reading the first line, use a much smaller block size
This helps speed up big file tree scans, especially over the network. For example, the previous default for S3, was 50MB - now we just read 9kB.

In a sample scan of a full BCH archive tree on S3, a scan of all files went from 21 minutes to 7. Still room for improvement there, but it's better.

# Fix 3: http: improve error handling
- Make all errors that we throw as a result of http_request() subclass from a single (new) error class: cfs.RequestError - this way it's easier to catch "did the http call fail"
- When auth fails, add a comment to the error string that we were trying to authenticate (vs a normal http call)
- When sending a request fails (i.e. we don't even have a response yet), retry it instead of marking it fatal. Epic has this happen a fair bit.
