### PR TITLE
json: fix previous scan early-exit commit by not exiting so early

### DIFF
--- a/cumulus_fhir_support/ml_json.py
+++ b/cumulus_fhir_support/ml_json.py
@@ -237,23 +237,24 @@ def _get_resource_type(
     pieces = set(NONLETTER.split(pathlib.Path(path).name))
     found_types = pieces & resource_info.ALL_RESOURCES
     if len(found_types) == 1:
-        return {path: found_types.pop()}
-
-    try:
-        # Check just the first record, as all records in a file should be the same resource.
-        # See https://www.hl7.org/fhir/R4/nd-json.html
-        #
-        # And since we cannot assume that "resourceType" is the first field,
-        # we must parse the whole first line.
-        # See https://www.hl7.org/fhir/R4/json.html#resources
-        if not (line := _read_first_line(path, fsspec_fs=fsspec_fs)):
+        resource_type = found_types.pop()
+    else:
+        # Try reading from file to see what resource type it holds.
+        try:
+            # Check just the first record, as all records in a file should be the same resource.
+            # See https://www.hl7.org/fhir/R4/nd-json.html
+            #
+            # And since we cannot assume that "resourceType" is the first field,
+            # we must parse the whole first line.
+            # See https://www.hl7.org/fhir/R4/json.html#resources
+            if not (line := _read_first_line(path, fsspec_fs=fsspec_fs)):
+                return {}
+            parsed = json.loads(line)
+        except Exception as exc:
+            logger.warning("Could not read from '%s': %s", path, str(exc))
             return {}
-        parsed = json.loads(line)
-    except Exception as exc:
-        logger.warning("Could not read from '%s': %s", path, str(exc))
-        return {}
 
-    resource_type = parsed.get("resourceType") if isinstance(parsed, dict) else None
+        resource_type = parsed.get("resourceType") if isinstance(parsed, dict) else None
 
     if target_resources is None or resource_type in target_resources:
         return {path: resource_type}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -192,11 +192,11 @@ class NdjsonTests(unittest.TestCase):
 
     @ddt.data(
         # target resources, expected answer
-        (None, {"pat1", "pat2", "con", "obs", "none", "non-dict"}),
+        (None, {"pat1", "pat2", "con", "Condition", "obs", "none", "non-dict"}),
         ([], []),
         ("Patient", {"pat1", "pat2"}),
-        ({"Condition", "Observation"}, {"con", "obs"}),
-        (iter(["Condition", None]), {"con", "none", "non-dict"}),
+        ({"Condition", "Observation"}, {"con", "Condition", "obs"}),
+        (iter(["Condition", None]), {"con", "Condition", "none", "non-dict"}),
     )
     @ddt.unpack
     def test_list_resource_filter(self, target_resources, expected_names):
@@ -207,6 +207,7 @@ class NdjsonTests(unittest.TestCase):
                     "pat1.ndjson": [{"resourceType": "Patient"}],
                     "pat2.ndjson": [{"resourceType": "Patient"}],
                     "con.ndjson": [{"resourceType": "Condition"}],
+                    "Condition.ndjson": [],
                     "obs.ndjson": [{"resourceType": "Observation"}],
                     "none.ndjson": [{"id": "no-resource-type"}],
                     "non-dict.ndjson": [5, 6],
@@ -224,6 +225,7 @@ class NdjsonTests(unittest.TestCase):
                 "pat1": "Patient",
                 "pat2": "Patient",
                 "con": "Condition",
+                "Condition": "Condition",
                 "obs": "Observation",
             }
 
@@ -339,6 +341,7 @@ class NdjsonTests(unittest.TestCase):
                         {"resourceType": "Condition", "id": "C1"},
                         {"resourceType": "Condition", "id": "C2"},
                     ],
+                    "Condition.ndjson": [],
                     "obs.ndjson.GZ": [{"resourceType": "Observation", "id": "O1"}],
                     "empty.ndjson": [],
                 },


### PR DESCRIPTION
Before this fix, we were skipping an important part of the scan, which is ignoring files that don't match the target resource.

This commit adds a few tests around it too.