### PR TITLE
client: retry fatal errors when doing OAuth reauthentication

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.1  # keep in rough sync with pyproject.toml
+    rev: v0.15.6  # keep in rough sync with pyproject.toml
     hooks:
       - name: Ruff formatting
         id: ruff-format

--- a/cumulus_fhir_support/auth.py
+++ b/cumulus_fhir_support/auth.py
@@ -98,7 +98,16 @@ class JwtAuth(Auth):
 
         try:
             response = await http.http_request(
-                session, "POST", self._config["token_endpoint"], data=auth_params
+                session,
+                "POST",
+                self._config["token_endpoint"],
+                data=auth_params,
+                # Retry fatal errors on reauthorization, because we've done this once before
+                # successfully, so we don't have reason to believe we'd really hit an error.
+                # We've seen Epic servers return bare 400 errors (the same error it gives for
+                # the wrong client credentials) in a flaky way when getting an access token.
+                # So on reauthorize, just retry any error the server gives us, it's likely flaky.
+                retry_fatals=reauthorize,
             )
             self._access_token = response.json().get("access_token")
         except http.NetworkError as exc:

--- a/cumulus_fhir_support/http.py
+++ b/cumulus_fhir_support/http.py
@@ -65,6 +65,7 @@ async def http_request(
     *,
     headers: dict | None = None,
     stream: bool = False,
+    retry_fatals: bool = False,
     retry_delays: Iterable[int] | None = None,
     request_callback: Callable[[], None] | None = None,
     error_callback: Callable[[NetworkError], None] | None = None,
@@ -82,6 +83,7 @@ async def http_request(
     :param url: URL to hit
     :param headers: optional header dictionary
     :param stream: whether to stream content in or load it all into memory at once
+    :param retry_fatals: whether to retry even fatal error codes like 404
     :param retry_delays: how many minutes to wait between retries, and how many retries to do,
                          defaults to [1, 1] which is three total tries across two minutes.
     :param request_callback: called right before each request
@@ -130,7 +132,8 @@ async def http_request(
         if error_callback:
             error_callback(error)
 
-        if delay is None or isinstance(error, FatalNetworkError):
+        is_fatal = not retry_fatals and isinstance(error, FatalNetworkError)
+        if delay is None or is_fatal:
             raise error
 
         response = error.response  # Note: may be None in case of DNS issues or the like

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,20 +19,6 @@ classifiers = [
 ]
 dynamic = ["description", "version"]
 
-[project.urls]
-"Homepage" = "https://github.com/smart-on-fhir/cumulus-fhir-support"
-
-[build-system]
-requires = ["flit_core >=3.4,<4"]
-build-backend = "flit_core.buildapi"
-
-[tool.flit.sdist]
-include = [
-    "tests/",
-    "LICENSE",
-    "*.md",
-]
-
 [project.optional-dependencies]
 tests = [
     "ddt",
@@ -46,7 +32,21 @@ dev = [
     "pre-commit",
     # Ruff is using minor versions for breaking changes until their 1.0 release.
     # See https://docs.astral.sh/ruff/versioning/
-    "ruff < 0.15",  # keep in rough sync with .pre-commit-config.yaml
+    "ruff < 0.16",  # keep in rough sync with .pre-commit-config.yaml
+]
+
+[project.urls]
+"Homepage" = "https://github.com/smart-on-fhir/cumulus-fhir-support"
+
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.flit.sdist]
+include = [
+    "tests/",
+    "LICENSE",
+    "*.md",
 ]
 
 [tool.ruff]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -460,6 +460,27 @@ IRxyq6i4LnRleQHDKzI0hdZJPEQd3k3RsPC9IsBf0A==
 
             self.assertEqual(2, self.respx_mock["token"].call_count)
 
+    @mock.patch("asyncio.sleep")
+    async def test_retry_oauth_reauth_fatals(self, sleep_mock):
+        """Verify that we retry fatals when reauthorizing."""
+        route = self.respx_mock.get(f"{self.server_url}/foo")
+        route.side_effect = [httpx.Response(401), httpx.Response(200)]
+
+        success = httpx.Response(200, json={"access_token": "1234"})
+        self.respx_mock["token"].side_effect = [success, httpx.Response(400), success]
+
+        async with cfs.FhirClient(
+            self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks
+        ) as server:
+            self.assertEqual(1, self.respx_mock["token"].call_count)
+
+            # Check that we correctly tried to re-authenticate through the fatals
+            response = await server.request("GET", "foo")
+            self.assertEqual(200, response.status_code)
+
+            self.assertEqual(3, self.respx_mock["token"].call_count)
+            self.assertEqual(sleep_mock.call_count, 1)
+
     @ddt.data(
         ('{"testing":"hi"}', ".JwKs", {"smart_jwks": {"keys": [{"testing": "hi"}]}}),
         ("hello world", ".PeM", {"smart_pem": "hello world"}),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -2,6 +2,7 @@
 
 import datetime
 import unittest
+from functools import partial
 from unittest import mock
 
 import ddt
@@ -130,6 +131,24 @@ class HttpTests(unittest.IsolatedAsyncioTestCase):
             cm.exception,
             cfs.TemporaryNetworkError if expect_retry else cfs.FatalNetworkError,
         )
+
+    @mock.patch("asyncio.sleep")
+    async def test_retry_fatals(self, sleep_mock):
+        self.respx_mock.get("http://example.com/").respond(status_code=400)
+
+        call = partial(
+            cfs.http_request, httpx.AsyncClient(), "GET", "http://example.com/", retry_delays=[1]
+        )
+
+        # Sanity check that without the flag, we don't retry the fatal
+        with self.assertRaises(cfs.FatalNetworkError):
+            await call()
+        self.assertEqual(sleep_mock.call_count, 0)
+
+        # Now with the flag, we do retry
+        with self.assertRaises(cfs.FatalNetworkError):
+            await call(retry_fatals=True)
+        self.assertEqual(sleep_mock.call_count, 1)
 
     @mock.patch("httpx.AsyncClient.send")
     @mock.patch("asyncio.sleep")


### PR DESCRIPTION
We've seen Epic servers give flaky 400 errors during token reauth. And since we've already authenticated before, it seems unlikely we'd hit true fatal errors, it's worth avoiding the flaky issues by just retrying.

This also adds a new flag to the public http.http_request() function: retry_fatals=False/True which will retry through fatals or not (defaulting to False).