### PR TITLE
Add new "clinical notes" set of utilities

### DIFF
--- a/cumulus_fhir_support/__init__.py
+++ b/cumulus_fhir_support/__init__.py
@@ -18,4 +18,17 @@ from .ml_json import (
     read_multiline_json_from_dir,
     read_multiline_json_with_details,
 )
+from .notes import (
+    NoteFilter,
+    RefScanner,
+    RefSet,
+    RefsNotFound,
+    RemoteAttachment,
+    anon_id,
+    anon_ref,
+    get_text_from_note_res,
+    make_note_filter,
+    make_note_ref_scanner,
+    note_res_has_text,
+)
 from .schemas import pyarrow_schema_from_rows

--- a/cumulus_fhir_support/notes.py
+++ b/cumulus_fhir_support/notes.py
@@ -1,0 +1,507 @@
+import base64
+import copy
+import email
+import hmac
+import re
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from typing import Protocol
+
+import inscriptis
+
+################
+# Anonymized IDs
+################
+
+
+def anon_id(id_val: str | None, salt: bytes | None) -> str | None:
+    """
+    Takes the provided FHIR ID and salt and makes a one-way hashed anonymous ID.
+
+    Salt should ideally have length 32 to match the sha256 digest used, and then the result will
+    also be exactly 64 characters long (the maximum FHIR ID length).
+
+    If input ID is empty, will return None; if salt is None, will return id_val.
+    """
+    if not id_val:
+        return None
+    if not salt:
+        return id_val
+    return hmac.new(salt, digestmod="sha256", msg=id_val.encode()).hexdigest()
+
+
+def anon_ref(ref_val: str | None, salt: bytes | None) -> str | None:
+    """If input ref is empty or not a ref, will return None; if salt is None, will not anonymize"""
+    if not ref_val:
+        return None
+    try:
+        res_type, id_val = ref_val.split("/", 1)
+    except ValueError:
+        return None
+    return f"{res_type}/{anon_id(id_val, salt)}"
+
+
+######################
+# Note text extraction
+######################
+
+
+class RemoteAttachment(ValueError):
+    """A note was requested, but it was only available remotely"""
+
+
+def note_res_has_text(note_res: dict) -> bool:
+    """
+    Returns whether this note resource has text available.
+
+    i.e. if this returns True, a call to get_text_from_note_res() should work.
+    (this is just a little faster because it won't actually process the HTML or text)
+
+    Should not normally raise an exception.
+    """
+    try:
+        attachment = _get_clinical_note_attachment(note_res)
+    except ValueError:
+        return False
+
+    return attachment.get("data") is not None
+
+
+def get_text_from_note_res(note_res: dict) -> str:
+    """
+    Returns the clinical text contained in the given note resource.
+
+    It will try to find the simplest version (plain text) or convert html to plain text if needed.
+
+    Will raise an exception if text cannot be found.
+    """
+    attachment = _get_clinical_note_attachment(note_res)
+    text = _get_note_from_attachment(attachment)
+
+    mimetype, _ = _parse_content_type(attachment["contentType"])
+    if mimetype in {"text/html", "application/xhtml+xml"}:
+        # An HTML note can confuse/stall NLP.
+        # It may include mountains of spans/styling or inline base64 images that aren't relevant
+        # to our interests.
+        #
+        # Inscriptis makes a very readable version of the note, with a focus on maintaining the
+        # HTML layout.
+        text = inscriptis.get_text(text)
+
+    return text.strip()
+
+
+def _parse_content_type(content_type: str) -> (str, str):
+    """Returns (mimetype, encoding)"""
+    msg = email.message.EmailMessage()
+    msg["content-type"] = content_type
+    return msg.get_content_type(), msg.get_content_charset("utf8")
+
+
+def _mimetype_priority(mimetype: str) -> int:
+    """
+    Returns priority of mimetypes for docref notes.
+
+    0 means "ignore"
+    Higher numbers are higher priority
+    """
+    if mimetype == "text/plain":
+        return 3
+    elif mimetype == "text/html":
+        return 2
+    elif mimetype == "application/xhtml+xml":
+        return 1
+    return 0
+
+
+def _get_note_from_attachment(attachment: dict) -> str:
+    """
+    Decodes a note from an attachment.
+
+    Note that it is assumed a contentType is provided.
+
+    :returns: the attachment's note text
+    """
+    _mimetype, charset = _parse_content_type(attachment["contentType"])
+
+    if attachment.get("data") is not None:
+        return base64.standard_b64decode(attachment["data"]).decode(charset)
+
+    if attachment.get("url") is not None:
+        raise RemoteAttachment(
+            "Some clinical note texts are only available via URL. "
+            "You may want to inline your notes with SMART Fetch."
+        )
+
+    # Shouldn't ever get here, because _get_clinical_note_attachment already checks this,
+    # but just in case...
+    raise ValueError("No data or url field present")  # pragma: no cover
+
+
+def _get_clinical_note_attachment(resource: dict) -> dict:
+    match resource["resourceType"]:
+        case "DiagnosticReport":
+            attachments = resource.get("presentedForm", [])
+        case "DocumentReference":
+            attachments = [
+                content["attachment"]
+                for content in resource.get("content", [])
+                if "attachment" in content
+            ]
+        case _:
+            raise ValueError(f"{resource['resourceType']} is not a supported clinical note type.")
+
+    # Find the best attachment to use, based on mimetype.
+    # We prefer basic text documents, to avoid confusing NLP with extra formatting (like <body>).
+    best_attachment_index = -1
+    best_attachment_priority = 0
+    for index, attachment in enumerate(attachments):
+        if "contentType" in attachment:
+            mimetype, _ = _parse_content_type(attachment["contentType"])
+            priority = _mimetype_priority(mimetype)
+            if priority > best_attachment_priority:
+                best_attachment_priority = priority
+                best_attachment_index = index
+
+    if best_attachment_index < 0:
+        # We didn't find _any_ of our target text content types.
+        raise ValueError("No textual mimetype found")
+
+    attachment = attachments[best_attachment_index]
+
+    if attachment.get("data") is None and not attachment.get("url"):
+        raise ValueError("No data or url field present")
+
+    return attachments[best_attachment_index]
+
+
+##########################
+# Collection of references
+##########################
+
+
+RefSetData = object | None
+
+
+class RefSet:  # noqa: PLW1641
+    """A class that holds a pile of FHIR resource references, with optional extra data for each"""
+
+    def __init__(self, *others: "str | RefSet"):
+        # Maps resource type -> set of IDs (with optional attached data)
+        self._ids: dict[str, dict[str, RefSetData]] = {}
+        for other in others:
+            if isinstance(other, str):
+                self.add_ref(other)
+            else:
+                self.add_set(other)
+
+    def add_id(self, res_type: str, id_val: str, *, data: RefSetData = None) -> None:
+        """Will overwrite any existing data for this ID"""
+        self._ids.setdefault(res_type, {})[id_val] = data
+
+    def add_ref(self, ref: str, *, data: RefSetData = None) -> None:
+        """Will overwrite any existing data for this ref"""
+        res_type, id_val = ref.split("/", 1)
+        self.add_id(res_type, id_val, data=data)
+
+    def add_set(self, other: "RefSet") -> None:
+        for res_type, ids in other._ids.items():
+            self._ids.setdefault(res_type, {}).update(copy.deepcopy(ids))
+
+    def get_data_for_id(
+        self, res_type: str, id_val: str, *, default: RefSetData = None
+    ) -> RefSetData:
+        return self._ids.get(res_type, {}).get(id_val, default)
+
+    def get_data_for_ref(self, ref: str, *, default: RefSetData = None) -> RefSetData:
+        res_type, id_val = ref.split("/", 1)
+        return self.get_data_for_id(res_type, id_val, default=default)
+
+    def has_id(self, res_type: str, id_val: str) -> bool:
+        return id_val in self._ids.get(res_type, {})
+
+    def has_ref(self, ref: str) -> bool:
+        res_type, id_val = ref.split("/", 1)
+        return self.has_id(res_type, id_val)
+
+    def has_type(self, res_type: str) -> bool:
+        return res_type in self._ids
+
+    def __bool__(self) -> bool:
+        return bool(self._ids)
+
+    def __contains__(self, ref: str) -> bool:
+        return self.has_ref(ref)
+
+    def __eq__(self, other: "RefSet") -> bool:
+        return self._ids == other._ids
+
+    def __iter__(self) -> Iterator:
+        """Returns a series of full references (e.g. "DocumentReference/1")"""
+        for res_type, ids in self._ids.items():
+            for ref_id in ids:
+                yield f"{res_type}/{ref_id}"
+
+    def __len__(self) -> int:
+        return sum(len(ids) for ids in self._ids.values())
+
+    def __str__(self) -> str:
+        return "{" + ", ".join(sorted(self)) + "}"
+
+
+#####################
+# Table ref discovery
+#####################
+
+
+class RefsNotFound(ValueError):
+    pass
+
+
+RefScanner = Callable[[Sequence[str]], str | None]
+
+
+def make_note_ref_scanner(columns: Iterable[str], *, is_anon: bool = False) -> RefScanner:
+    """
+    Returns a scanner function you can call on rows of data, to find note and patient references.
+
+    This is useful if you have a csv file or a SQL table that you want to search through for
+    columns that indicate note resource refs.
+
+    It will look for columns like note_ref, documentreference_id, etc.
+
+    Patient refs are only included as a last resort, if note IDs columns are not found.
+    """
+    columns = [col.casefold() for col in columns]
+    return _make_ref_getter(columns, is_anon=is_anon)
+
+
+def _make_ref_getter(fieldnames: Sequence[str], *, is_anon: bool = False) -> RefScanner:
+    """Returns a callable that returns (note ref, patient ref)"""
+    get_dxr = _find_header(fieldnames, "DiagnosticReport", is_anon=is_anon)
+    get_doc = _find_header(fieldnames, "DocumentReference", is_anon=is_anon)
+    get_pat = _find_header(fieldnames, "Patient", is_anon=is_anon)
+
+    if not get_dxr and not get_doc and not get_pat:
+        raise RefsNotFound("No patient or note IDs found.")
+
+    # A method that takes a row of a table and returns a patient/note ref from it
+    def getter(row: Sequence[str]) -> str | None:
+        if get_dxr:
+            if val := get_dxr(row):
+                return val
+        if get_doc:
+            if val := get_doc(row):
+                return val
+        # If and only if we don't have any resource ID matchers, we'll check by patient
+        if not get_dxr and not get_doc and get_pat:
+            if val := get_pat(row):
+                return val
+        return None
+
+    return getter
+
+
+def _find_header(
+    fieldnames: Sequence[str], res_type: str, *, is_anon: bool = False
+) -> Callable[[Sequence[str]], str | None] | None:
+    folded = res_type.casefold()
+    id_names = [f"{folded}_id"]
+    ref_names = [f"{folded}_ref"]
+
+    if res_type in {"DiagnosticReport", "DocumentReference"}:
+        ref_names.append("document_ref")
+        ref_names.append("note_ref")
+    if res_type == "DocumentReference":
+        id_names.append("docref_id")
+    if res_type == "Patient":
+        id_names.append("subject_id")
+        ref_names.append("subject_ref")
+
+    if is_anon:
+        # Look for both anon_ and normal versions, but prefer an explicit column in case both exist
+        id_names = [f"anon_{x}" for x in id_names] + id_names
+        ref_names = [f"anon_{x}" for x in ref_names] + ref_names
+
+    for field in id_names:
+        if field in fieldnames:
+            idx = fieldnames.index(field)
+            return lambda x: f"{res_type}/{x[idx]}" if x[idx] else None
+    for field in ref_names:
+        if field in fieldnames:
+            idx = fieldnames.index(field)
+            prefix = f"{res_type}/"
+            return lambda x: x[idx] if x[idx].startswith(prefix) else None
+
+    return None
+
+
+################
+# Note filtering
+################
+
+
+class NoteFilter(Protocol):
+    def __call__(self, note_res: dict, *, text: str | None = None) -> bool:
+        """
+        Takes a note resource (DxReport or DocRef) and returns True/False.
+
+        If `text` is None, the text will be pulled from the note resource (so you only need to pass
+        it if you already have it or as an optimization over multiple NoteFilter calls).
+        """
+
+
+_ESCAPED_WHITESPACE = re.compile(r"(\\\s)+")
+
+
+def make_note_filter(
+    *,
+    reject_by_regex: Iterable[str] | None = None,
+    reject_by_word: Iterable[str] | None = None,
+    select_by_regex: Iterable[str] | None = None,
+    select_by_word: Iterable[str] | None = None,
+    select_by_ref: RefSet | None = None,
+    salt: bytes | None = None,
+) -> NoteFilter:
+    """
+    Creates a callable NoteFilter that encodes the select_by and reject_by arguments.
+
+    Even if passed no arguments, note status is always checked (to reject preliminary or
+    entered-in-error notes).
+
+    The select_by_ref argument will be matched on direct DocumentReference or DiagnosticReport
+    matches, as well as Patient matches for note subjects.
+
+    Provide a salt if select_by_ref holds anonymized refs.
+    """
+
+    pattern = _compile_filter_regex(
+        reject_by_regex=reject_by_regex,
+        reject_by_word=reject_by_word,
+        select_by_regex=select_by_regex,
+        select_by_word=select_by_word,
+    )
+
+    def note_filter(note_res: dict, *, text: str | None = None) -> bool:
+        if not _filter_status(note_res):
+            return False
+
+        if not _filter_refs(note_res, salt=salt, select_by_ref=select_by_ref):
+            return False
+
+        if pattern is not None:
+            if text is None:
+                try:
+                    text = get_text_from_note_res(note_res)
+                except Exception:
+                    text = ""  # to allow passing if we only have reject_by_*
+
+            if pattern.search(text) is None:
+                return False
+
+        return True
+
+    return note_filter
+
+
+def _filter_status(note_res: dict) -> bool:
+    """If the resource status is WIP, obsolete, or entered-in-error, reject it"""
+    note_type = note_res.get("resourceType")
+    note_id = note_res.get("id")
+
+    # Require basic resource fields, so that other filters can use these without guards
+    if not note_type or not note_id:
+        return False
+
+    match note_type:
+        case "DiagnosticReport":
+            valid_status_types = {"final", "amended", "corrected", "appended", "unknown", None}
+            return note_res.get("status") in valid_status_types
+
+        case "DocumentReference":
+            good_status = note_res.get("status") in {"current", None}  # status of DocRef itself
+            # docStatus is status of clinical note attachments
+            good_doc_status = note_res.get("docStatus") in {"final", "amended", None}
+            return good_status and good_doc_status
+
+        case _:
+            return False
+
+
+def _filter_refs(
+    note_res: dict,
+    *,
+    salt: bytes | None,
+    select_by_ref: RefSet | None,
+) -> bool:
+    """Returns False if refs are provided and this note doesn't match any of them"""
+    if not select_by_ref:
+        return True
+
+    if select_by_ref.has_type("Patient"):
+        # Both DxReports and DocRefs use subject
+        subject_ref = anon_ref(note_res.get("subject", {}).get("reference"), salt)
+        if subject_ref not in select_by_ref:
+            return False
+
+    if select_by_ref.has_type("DiagnosticReport") or select_by_ref.has_type("DocumentReference"):
+        note_ref = f"{note_res['resourceType']}/{anon_id(note_res['id'], salt)}"
+        if note_ref not in select_by_ref:
+            return False
+
+    return True
+
+
+def _user_regex_to_pattern(term: str) -> str:
+    """Takes a user search regex and adds some boundaries to it"""
+    # Make a custom version of \b that allows non-word characters to be on edge of the term too.
+    # For example:
+    #   This misses: re.match(r"\ba\+\b", "a+")
+    #   But this hits: re.match(r"\ba\+", "a+")
+    # So to work around that, we look for the word boundary ourselves.
+    edge = r"(\W|$|^)"
+    return f"{edge}({term}){edge}"
+
+
+def _user_word_to_pattern(term: str) -> str:
+    """Takes a user search term and turns it into a clinical-note-appropriate regex"""
+    term = re.escape(term)
+    # Allow multi-word "words" (like "severe cough") have any kind of whitespace in between them,
+    # as they may cross line endings in the note (which can happen for normal paragraph wrapping).
+    term = _ESCAPED_WHITESPACE.sub(r"\\s+", term)
+    return _user_regex_to_pattern(term)
+
+
+def _combine_regexes(*, by_regex: Iterable[str] | None, by_word: Iterable[str] | None) -> str:
+    patterns = []
+    if by_regex:
+        patterns.extend(_user_regex_to_pattern(regex) for regex in set(by_regex))
+    if by_word:
+        patterns.extend(_user_word_to_pattern(word) for word in set(by_word))
+    return "|".join(patterns)
+
+
+def _compile_filter_regex(
+    *,
+    reject_by_regex: Iterable[str] | None,
+    reject_by_word: Iterable[str] | None,
+    select_by_regex: Iterable[str] | None,
+    select_by_word: Iterable[str] | None,
+) -> re.Pattern | None:
+    select = _combine_regexes(by_word=select_by_word, by_regex=select_by_regex)
+
+    reject = _combine_regexes(by_word=reject_by_word, by_regex=reject_by_regex)
+    if reject:
+        # Use negative lookahead
+        reject = rf"^(?!.*{reject})"
+
+    if reject and select:
+        # Add positive lookahead
+        final = f"{reject}(?=.*{select})"
+    elif reject:
+        final = reject
+    elif select:
+        final = select
+    else:
+        return None
+
+    return re.compile(final, re.IGNORECASE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires-python = ">= 3.10"
 dependencies = [
     "fhirclient >= 4.1",
     "httpx",
+    "inscriptis",
     "jwcrypto",
     "pyarrow >= 12",
 ]

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,554 @@
+import base64
+import binascii
+import unittest
+
+import ddt
+
+import cumulus_fhir_support as cfs
+
+# Some convenience salt values to use
+SALT_STR = "e359191164cd209708d93551f481edd048946a9d844c51dea1b64d3f83dfd1fa"
+SALT_BYTES = binascii.unhexlify(SALT_STR)
+
+
+@ddt.ddt
+class NoteTests(unittest.TestCase):
+    @ddt.data(
+        (None, None),
+        ("", None),
+        ("abc", "75b245a08d21040487dde2efe7038f93ea7ecb06dfc1dc7275e4ad3a22f57a22"),
+    )
+    @ddt.unpack
+    def test_anon_id(self, id_val, expected):
+        assert cfs.anon_id(id_val, SALT_BYTES) == expected
+
+    @ddt.data(
+        (None, None),
+        ("", None),
+        ("abc", None),
+        ("Device/abc", "Device/75b245a08d21040487dde2efe7038f93ea7ecb06dfc1dc7275e4ad3a22f57a22"),
+    )
+    @ddt.unpack
+    def test_anon_ref(self, ref_val, expected):
+        assert cfs.anon_ref(ref_val, SALT_BYTES) == expected
+
+    @ddt.data(
+        (  # simple DxReport text
+            "DiagnosticReport",
+            [("text/plain", "hello", "url")],
+            "hello",
+        ),
+        (  # simple DocRef text
+            "DocumentReference",
+            [("text/plain", "hello", "url")],
+            "hello",
+        ),
+        (  # prefer text over any html variant
+            "DocumentReference",
+            [
+                ("text/html", "html", None),
+                ("text/plain", "text", None),
+                ("application/xhtml+xml", "xhtml", None),
+            ],
+            "text",
+        ),
+        (  # prefer html over xhtml
+            "DocumentReference",
+            [("text/html", "html", None), ("application/xhtml+xml", "xhtml", None)],
+            "html",
+        ),
+        (  # but accept xhtml
+            "DocumentReference",
+            [("application/xhtml+xml", "xhtml", None)],
+            "xhtml",
+        ),
+        (  # strips html
+            "DocumentReference",
+            [("text/html", "<html><body>He<b>llooooo</b></html>", None)],
+            "Hellooooo",
+        ),
+        (  # strips xhtml
+            "DocumentReference",
+            [("application/xhtml+xml", "<html><body>He<b>llooooo</b></html>", None)],
+            "Hellooooo",
+        ),
+        (  # does not strips text
+            "DocumentReference",
+            [("text/plain", "<html><body>He<b>llooooo</b></html>", None)],
+            "<html><body>He<b>llooooo</b></html>",
+        ),
+        (  # strips surrounding whitespace
+            "DocumentReference",
+            [("text/plain", "\n\n hello   world \n\n", None)],
+            "hello   world",
+        ),
+        (  # respects charset
+            "DiagnosticReport",
+            [("text/plain; charset=utf16", b"\xff\xfeh\x00e\x00l\x00l\x00o\x00", None)],
+            "hello",
+        ),
+        (  # bad charset
+            "DiagnosticReport",
+            [("text/plain", b"\xff\xfeh\x00e\x00l\x00l\x00o\x00", None)],
+            (UnicodeDecodeError, "invalid start byte"),
+        ),
+        (  # unsupported mime type
+            "DiagnosticReport",
+            [("application/pdf", "pdf", None)],
+            (ValueError, "No textual mimetype found"),
+        ),
+        (  # no attachments
+            "DiagnosticReport",
+            [],
+            (ValueError, "No textual mimetype found"),
+        ),
+        (  # url only
+            "DiagnosticReport",
+            [("text/plain", None, "url")],
+            (cfs.RemoteAttachment, "only available via URL"),
+        ),
+        (  # bad resource type
+            "Patient",
+            [],
+            (ValueError, "Patient is not a supported clinical note type"),
+        ),
+        (  # no data or url
+            "DocumentReference",
+            [("text/plain", None, None)],
+            (ValueError, "No data or url field present"),
+        ),
+    )
+    @ddt.unpack
+    def test_get_text_from_note_res(self, res_type, attachments, result):
+        note_res = {"resourceType": res_type}
+
+        # Build attachment list
+        attachments = [
+            {
+                "contentType": attachment[0],
+                "data": attachment[1],
+                "url": attachment[2],
+            }
+            for attachment in attachments
+        ]
+        for attachment in attachments:
+            if data := attachment["data"]:
+                if isinstance(data, str):
+                    data = data.encode()
+                attachment["data"] = base64.standard_b64encode(data).decode()
+        if res_type == "DiagnosticReport":
+            note_res["presentedForm"] = attachments
+        elif res_type == "DocumentReference":
+            note_res["content"] = [{"attachment": a} for a in attachments]
+
+        # Grab text and compare
+        if isinstance(result, str):
+            assert cfs.note_res_has_text(note_res) is True
+            assert cfs.get_text_from_note_res(note_res) == result
+        else:
+            has_text = result[0] is UnicodeDecodeError
+            assert cfs.note_res_has_text(note_res) == has_text, result
+            with self.assertRaisesRegex(*result):
+                cfs.get_text_from_note_res(note_res)
+
+    def test_ref_set(self):
+        assert bool(cfs.RefSet()) is False
+
+        # Inspecting the set
+        refs = cfs.RefSet("Device/d", "Patient/p")
+        assert bool(refs) is True
+        assert list(refs) == ["Device/d", "Patient/p"]
+        assert str(refs) == "{Device/d, Patient/p}"
+        assert refs == cfs.RefSet("Device/d", "Patient/p")
+        assert refs != cfs.RefSet("Patient/p")
+        assert refs.has_type("Patient")
+        assert not refs.has_type("Condition")
+        assert refs.has_ref("Device/d")
+        assert not refs.has_ref("Condition/c")
+        assert "Patient/p" in refs
+        assert "Patient/x" not in refs
+        assert refs.has_id("Device", "d")
+        assert not refs.has_id("Condition", "c")
+
+        # Modifying the set
+        new_refs = cfs.RefSet(refs)
+        assert refs == new_refs
+        refs.add_id("Encounter", "e")
+        refs.add_ref("Observation/o")
+        assert refs != new_refs
+        new_refs.add_set(refs)
+        assert refs == new_refs
+        assert len(refs) == 4
+
+        # Attached data
+        data = ["extra", "data"]
+        refs = cfs.RefSet()
+        refs.add_id("Device", "d", data=data)
+        refs.add_ref("Patient/p", data=5)
+        assert refs.get_data_for_id("Patient", "x", default=10) == 10
+        assert refs.get_data_for_id("Patient", "p", default=10) == 5
+        assert refs.get_data_for_ref("Observation/x") is None
+        assert refs.get_data_for_ref("Observation/x", default="hello") == "hello"
+        assert refs.get_data_for_ref("Device/d") is data
+        new_refs = cfs.RefSet(refs)  # will deepcopy data
+        assert new_refs.get_data_for_id("Patient", "p") == 5
+        assert new_refs.get_data_for_ref("Device/d") == data
+        assert new_refs.get_data_for_ref("Device/d") is not data
+
+    @ddt.data(
+        (  # basic id match
+            "patient_id,DocumentREFERENCE_ID",
+            "xxx,yyy",
+            "DocumentReference/yyy",
+        ),
+        (  # basic ref match
+            "patient_id,diagnosticreport_ref",
+            "xxx,DiagnosticReport/yyy",
+            "DiagnosticReport/yyy",
+        ),
+        (  # custom document_ref alias
+            "patient_id,document_ref",
+            "xxx,DiagnosticReport/ref",
+            "DiagnosticReport/ref",
+        ),
+        (  # custom note_ref alias
+            "patient_id,note_ref",
+            "xxx,DocumentReference/ref",
+            "DocumentReference/ref",
+        ),
+        (  # custom docref_id alias
+            "patient_id,docref_id",
+            "xxx,ref",
+            "DocumentReference/ref",
+        ),
+        (  # patient id match (can't be note ref in there)
+            "patient_id,other_col",
+            "xxx,blarg",
+            "Patient/xxx",
+        ),
+        (  # patient ref match (can't be note ref in there)
+            "patient_ref,other_col",
+            "Patient/abc,blarg",
+            "Patient/abc",
+        ),
+        (  # custom subject_id alias
+            "subject_id,other_col",
+            "abc,blarg",
+            "Patient/abc",
+        ),
+        (  # custom subject_ref alias
+            "subject_ref,other_col",
+            "Patient/abc,blarg",
+            "Patient/abc",
+        ),
+        (  # prefer anon version of id columns
+            "anon_patient_id,patient_id",
+            "anon,orig",
+            "Patient/anon",
+        ),
+        (  # prefer anon version of ref columns
+            "note_ref,anon_note_ref",
+            "DocumentReference/orig,DocumentReference/anon",
+            "DocumentReference/anon",
+        ),
+        (  # with competing columns, we will pick the non-empty one
+            "diagnosticreport_id,documentreference_id",
+            ",docref",
+            "DocumentReference/docref",
+        ),
+        (  # unsupported ref type
+            "note_ref",
+            "Patient/abc",
+            None,
+        ),
+        (  # no valid cols found
+            "other,nope",
+            "xxx,yyy",
+            ValueError,
+        ),
+    )
+    @ddt.unpack
+    def test_make_note_ref_scanner(self, cols, row, result):
+        cols = cols.split(",")
+        row = row.split(",")
+
+        if isinstance(result, type):
+            with self.assertRaises(result):
+                cfs.make_note_ref_scanner(cols)
+        else:
+            scanner = cfs.make_note_ref_scanner(cols, is_anon=True)
+            assert result == scanner(row), cols
+
+    @ddt.data(
+        (  # default, no regexes, no status - should pass
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "",
+            {},
+            True,
+        ),
+        (  # unsupported type
+            {"resourceType": "Patient", "id": "1"},
+            "",
+            {},
+            False,
+        ),
+        (  # No ID
+            {"resourceType": "DiagnosticReport"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "registered"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "partial"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "preliminary"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "cancelled"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "entered-in-error"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DocumentReference", "id": "1", "status": "superseded"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DocumentReference", "id": "1", "status": "entered-in-error"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad docStatus
+            {"resourceType": "DocumentReference", "id": "1", "docStatus": "preliminary"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad docStatus
+            {"resourceType": "DocumentReference", "id": "1", "docStatus": "entered-in-error"},
+            "",
+            {},
+            False,
+        ),
+        (  # select word (negative case)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"select_by_word": {"bye"}},
+            False,
+        ),
+        (  # select word (positive case)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello, world",
+            {"select_by_word": {"hello"}},
+            True,
+        ),
+        (  # select word (multiple selections, or'd together)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"select_by_word": {"bye", "hello"}},
+            True,
+        ),
+        (  # select word (weird characters)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hel*lo.1+ world",
+            {"select_by_word": {"hel*lo.1+"}},
+            True,
+        ),
+        (  # select word (substring isn't matched)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"select_by_word": {"hell"}},
+            False,
+        ),
+        (  # select word (multi word)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world, mr smith",
+            {"select_by_word": {"mr smith"}},
+            True,
+        ),
+        (  # select regex (matches)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"select_by_regex": {"hell."}},
+            True,
+        ),
+        (  # select regex (can cross word boundaries)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"select_by_regex": {"hell.*d"}},
+            True,
+        ),
+        (  # select regex (can cross word boundaries, but still respects word ends)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"select_by_regex": {"hell.*r"}},
+            False,
+        ),
+        (  # select word and regex (matches either)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"select_by_word": {"world"}, "select_by_regex": {"h."}},
+            True,
+        ),
+        (  # reject word (by itself, without matching, we should select note)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_word": {"bye"}},
+            True,
+        ),
+        (  # reject word (by itself, with matching, we should reject note)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_word": {"hello"}},
+            False,
+        ),
+        (  # reject word (multiple options, will reject either)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_word": {"hello", "bye"}},
+            False,
+        ),
+        (  # reject word (and select it, reject should win)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_word": {"hello"}, "select_by_word": {"hello"}},
+            False,
+        ),
+        (  # reject word (miss) and select word (hit)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_word": {"bye"}, "select_by_word": {"hello"}},
+            True,
+        ),
+        (  # reject regex (simple match)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_regex": {"he..o"}},
+            False,
+        ),
+        (  # reject regex (across words)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_regex": {"he.*rld"}},
+            False,
+        ),
+        (  # reject word and regex (either should reject)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello world",
+            {"reject_by_regex": {"he..o"}, "reject_by_word": {"bye"}},
+            False,
+        ),
+        (  # select on non-first lines
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello\nworld",
+            {"select_by_word": {"world"}},
+            True,
+        ),
+        (  # reject on non-first lines
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello\nworld",
+            {"reject_by_word": {"world"}},
+            False,
+        ),
+        (  # select across lines and whitespace, if multiple words provided
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello  \n  world",
+            {"select_by_word": {"hello world"}},
+            True,
+        ),
+        (  # (don't) select across lines with other stuff in there, confirming a lack of match
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            "hello\n.world",
+            {"select_by_word": {"hello world"}},
+            False,
+        ),
+        (  # select note ref
+            {"resourceType": "DocumentReference", "id": "1"},
+            "",
+            {
+                "select_by_ref": cfs.RefSet(
+                    "DocumentReference/69123f5b2305aba4bc734b41c66cedab639b3e81d4ae8eeb9569d6dc1476a1e7"
+                )
+            },
+            True,
+        ),
+        (  # select note ref and word (miss on ref, so we never consider the word)
+            {"resourceType": "DocumentReference", "id": "1"},
+            "hello world",
+            {"select_by_ref": cfs.RefSet("DocumentReference/xxx"), "select_by_word": {"world"}},
+            False,
+        ),
+        (  # select patient ref
+            {"resourceType": "DiagnosticReport", "id": "1", "subject": {"reference": "Patient/1"}},
+            "",
+            {
+                "select_by_ref": cfs.RefSet(
+                    "Patient/69123f5b2305aba4bc734b41c66cedab639b3e81d4ae8eeb9569d6dc1476a1e7"
+                )
+            },
+            True,
+        ),
+        (  # select patient ref (miss)
+            {"resourceType": "DiagnosticReport", "id": "1", "subject": {"reference": "Patient/1"}},
+            "",
+            {"select_by_ref": cfs.RefSet("Patient/xxx")},
+            False,
+        ),
+        (  # pulls text if not provided ("hello world")
+            {
+                "resourceType": "DiagnosticReport",
+                "id": "1",
+                "presentedForm": [{"contentType": "text/plain", "data": "aGVsbG8gd29ybGQ="}],
+            },
+            None,
+            {"select_by_word": {"hello"}},
+            True,
+        ),
+        (  # select by word with no text at all (fails)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            None,
+            {"select_by_word": {"hello"}},
+            False,
+        ),
+        (  # reject by word with no text at all (passes)
+            {"resourceType": "DiagnosticReport", "id": "1"},
+            None,
+            {"reject_by_word": {"hello"}},
+            True,
+        ),
+    )
+    @ddt.unpack
+    def test_note_filter(self, res, text, kwargs, selected):
+        note_filter = cfs.make_note_filter(**kwargs, salt=SALT_BYTES)
+        assert note_filter(res, text=text) is selected, kwargs
+
+    def test_note_filter_no_salt(self):
+        doc = {"resourceType": "DiagnosticReport", "id": "1"}
+
+        note_filter = cfs.make_note_filter(select_by_ref=cfs.RefSet("DiagnosticReport/0"))
+        assert note_filter(doc) is False
+
+        note_filter = cfs.make_note_filter(select_by_ref=cfs.RefSet("DiagnosticReport/1"))
+        assert note_filter(doc) is True


### PR DESCRIPTION
- Generate anonymized IDs
- Get text from a note resource
- Extract note refs from a table/csv
- Filter notes based off of regexes, words, and refs

This kind of code is now needed in both Cumulus ETL and Library, so it makes sense to consolidate the logic here.