### PR TITLE
RefSet: allow checking if None is in the set

### DIFF
--- a/cumulus_fhir_support/notes.py
+++ b/cumulus_fhir_support/notes.py
@@ -219,7 +219,9 @@ class RefSet:  # noqa: PLW1641
     def has_id(self, res_type: str, id_val: str) -> bool:
         return id_val in self._ids.get(res_type, {})
 
-    def has_ref(self, ref: str) -> bool:
+    def has_ref(self, ref: str | None) -> bool:
+        if not ref or "/" not in ref:
+            return False
         res_type, id_val = ref.split("/", 1)
         return self.has_id(res_type, id_val)
 
@@ -229,7 +231,7 @@ class RefSet:  # noqa: PLW1641
     def __bool__(self) -> bool:
         return bool(self._ids)
 
-    def __contains__(self, ref: str) -> bool:
+    def __contains__(self, ref: str | None) -> bool:
         return self.has_ref(ref)
 
     def __eq__(self, other: "RefSet") -> bool:

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -165,6 +165,8 @@ class NoteTests(unittest.TestCase):
         assert not refs.has_type("Condition")
         assert refs.has_ref("Device/d")
         assert not refs.has_ref("Condition/c")
+        assert not refs.has_ref(None)
+        assert not refs.has_ref("other text")
         assert "Patient/p" in refs
         assert "Patient/x" not in refs
         assert refs.has_id("Device", "d")


### PR DESCRIPTION
It will never be true, but this lets consumers not have to guard checks as much.