### PR TITLE
Don't specify ServerSideEncryption

### DIFF
--- a/cumulus_fhir_support/io.py
+++ b/cumulus_fhir_support/io.py
@@ -49,13 +49,10 @@ class FsPath:
         ### S3 ###
         s3 = {}
 
-        # We want to enforce server side encryption, because FHIR data is sensitive.
-        s3["s3_additional_kwargs"] = {"ServerSideEncryption": "aws:kms"}
-
         if endpoint_url:
             s3["endpoint_url"] = endpoint_url
         if kms_key:
-            s3["s3_additional_kwargs"]["SSEKMSKeyId"] = kms_key
+            s3["s3_additional_kwargs"] = {"SSEKMSKeyId": kms_key}
         if region:
             s3["client_kwargs"] = {"region_name": region}
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -116,9 +116,7 @@ class IoTests(unittest.TestCase):
         # Confirm the filesystem used got the options
         self.assertEqual(s3.fs.endpoint_url, "yup")
         self.assertEqual(s3.fs.client_kwargs, {"region_name": "region"})
-        self.assertEqual(
-            s3.fs.s3_additional_kwargs, {"SSEKMSKeyId": "kms", "ServerSideEncryption": "aws:kms"}
-        )
+        self.assertEqual(s3.fs.s3_additional_kwargs, {"SSEKMSKeyId": "kms"})
 
     def test_custom_fs(self):
         fs = fsspec.filesystem("s3")


### PR DESCRIPTION
AWS will use bucket default (which is encrypted by default nowadays) and specifying it can confuse boto sometimes.